### PR TITLE
Remove OCMock dependency

### DIFF
--- a/AGSnapshotHelper.podspec
+++ b/AGSnapshotHelper.podspec
@@ -15,5 +15,4 @@ Pod::Spec.new do |s|
     s.frameworks       = 'XCTest', 'UIKit', 'Foundation'
 
     s.dependency 'FBSnapshotTestCase/Core', '~> 2.0'
-    s.dependency 'OCMock', '~> 3.2'
 end

--- a/Example/AGSnapshotHelperExample.xcodeproj/project.pbxproj
+++ b/Example/AGSnapshotHelperExample.xcodeproj/project.pbxproj
@@ -285,13 +285,11 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-AGSnapshotHelperExampleTests/Pods-AGSnapshotHelperExampleTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AGSnapshotHelper/AGSnapshotHelper.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
-				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AGSnapshotHelper.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,13 +1,11 @@
 PODS:
   - AGSnapshotHelper (0.0.1):
     - FBSnapshotTestCase/Core (~> 2.0)
-    - OCMock (~> 3.2)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - OCMock (3.4.1)
 
 DEPENDENCIES:
   - AGSnapshotHelper (from `..`)
@@ -18,9 +16,8 @@ EXTERNAL SOURCES:
     :path: ..
 
 SPEC CHECKSUMS:
-  AGSnapshotHelper: 5e102a001e422401437038947ce6260960a2d8c3
+  AGSnapshotHelper: 760d9736f4db590193f421f0ab21087fcfe8170b
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
 
 PODFILE CHECKSUM: f4185fb79ccff9ca8f3ede1b73c26b837875b20f
 

--- a/Pod/Classes/AGPreferredContentSizeCategoryMocker.m
+++ b/Pod/Classes/AGPreferredContentSizeCategoryMocker.m
@@ -7,9 +7,9 @@
 //
 
 #import "AGPreferredContentSizeCategoryMocker.h"
+#import "UIApplication+PreferredContentSizeCategoryMock.h"
 
-#import <UIKit/UIKit.h>
-#import <OCMock/OCMock.h>
+@import UIKit;
 
 @interface AGPreferredContentSizeCategoryMocker ()
 
@@ -20,15 +20,11 @@
 @implementation AGPreferredContentSizeCategoryMocker
 
 - (void)startMockingPreferredContentSizeCategory:(NSString *)contentSizeCategory {
-
-    self.applicationMock = OCMPartialMock([UIApplication sharedApplication]);
-    OCMStub([self.applicationMock preferredContentSizeCategory]).andReturn(contentSizeCategory);
+    [UIApplication sharedApplication].mockedContentSizeCategory = contentSizeCategory;
 }
 
 - (void)stopMockingPreferredContentSizeCategory {
-
-    [(id)self.applicationMock stopMocking];
-    self.applicationMock = nil;
+    [UIApplication sharedApplication].mockedContentSizeCategory = nil;
 }
 
 @end

--- a/Pod/Classes/Categories/UIApplication+PreferredContentSizeCategoryMock.h
+++ b/Pod/Classes/Categories/UIApplication+PreferredContentSizeCategoryMock.h
@@ -8,8 +8,16 @@
 
 @import UIKit;
 
+/**
+ `UIApplication` extension for `-preferredContentSizeCategory` property mocking.
+ */
 @interface UIApplication (PreferredContentSizeCategoryMock)
 
+
+/**
+ Sets `UIContentSizeCategory` value to mock.
+ To disable mocking `-preferredContentSizeCategory`, set property to `nil`.
+ */
 @property (nonatomic, strong, nullable) UIContentSizeCategory mockedContentSizeCategory;
 
 @end

--- a/Pod/Classes/Categories/UIApplication+PreferredContentSizeCategoryMock.h
+++ b/Pod/Classes/Categories/UIApplication+PreferredContentSizeCategoryMock.h
@@ -1,0 +1,23 @@
+//
+//  UIApplication+PreferredContentSizeCategoryMock.h
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 15/08/2017.
+//  Copyright © 2017 Grupa Allegro. All rights reserved.
+//
+
+@import UIKit;
+
+/**
+ `UIApplication` extension for `-preferredContentSizeCategory` property mocking.
+ */
+@interface UIApplication (PreferredContentSizeCategoryMock)
+
+
+/**
+ Sets `UIContentSizeCategory` value to mock.
+ To disable mocking `-preferredContentSizeCategory`, set property to `nil`.
+ */
+@property (nonatomic, strong, nullable) UIContentSizeCategory mockedContentSizeCategory;
+
+@end

--- a/Pod/Classes/Categories/UIApplication+PreferredContentSizeCategoryMock.h
+++ b/Pod/Classes/Categories/UIApplication+PreferredContentSizeCategoryMock.h
@@ -1,0 +1,15 @@
+//
+//  UIApplication+PreferredContentSizeCategoryMock.h
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 15/08/2017.
+//  Copyright © 2017 Grupa Allegro. All rights reserved.
+//
+
+@import UIKit;
+
+@interface UIApplication (PreferredContentSizeCategoryMock)
+
+@property (nonatomic, strong, nullable) UIContentSizeCategory mockedContentSizeCategory;
+
+@end

--- a/Pod/Classes/Categories/UIApplication+PreferredContentSizeCategoryMock.m
+++ b/Pod/Classes/Categories/UIApplication+PreferredContentSizeCategoryMock.m
@@ -1,0 +1,66 @@
+//
+//  UIApplication+PreferredContentSizeCategoryMock.m
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 15/08/2017.
+//  Copyright © 2017 Grupa Allegro. All rights reserved.
+//
+
+#import "UIApplication+PreferredContentSizeCategoryMock.h"
+#import <objc/runtime.h>
+
+static char kContentSizeCategoryKey;
+
+@implementation UIApplication (PreferredContentSizeCategoryMock)
+
+#pragma mark - Public
+
+- (void)setMockedContentSizeCategory:(UIContentSizeCategory)contentSizeCategory {
+    objc_setAssociatedObject(self, &kContentSizeCategoryKey, contentSizeCategory, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (UIContentSizeCategory)mockedContentSizeCategory {
+    return objc_getAssociatedObject(self, &kContentSizeCategoryKey);
+}
+
+#pragma mark - Private
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+
+        SEL originalSelector = @selector(preferredContentSizeCategory);
+        SEL swizzledSelector = @selector(ag_preferredContentSizeCategory);
+
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+
+        BOOL didAddMethod = class_addMethod(class,
+                                            originalSelector,
+                                            method_getImplementation(swizzledMethod),
+                                            method_getTypeEncoding(swizzledMethod));
+
+        if (didAddMethod) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
+#pragma mark - Method Swizzling
+
+- (UIContentSizeCategory)ag_preferredContentSizeCategory {
+    UIContentSizeCategory contentSizeCategoryToMock = self.mockedContentSizeCategory;
+    if (contentSizeCategoryToMock != nil) {
+        return contentSizeCategoryToMock;
+    }
+
+    return [self ag_preferredContentSizeCategory];
+}
+
+@end

--- a/Tests/AGSnapshotHelper.xcodeproj/project.pbxproj
+++ b/Tests/AGSnapshotHelper.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2AB667C9DD82734696AE3293 /* libPods-AGSnapshotHelperTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 394AE5D97523A05453B9202D /* libPods-AGSnapshotHelperTests.a */; };
 		4144A6141D00CC4D009B134D /* AGSampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4144A6131D00CC4D009B134D /* AGSampleView.m */; };
 		415093CA1C498BD900F17144 /* FBSnapshotTestCase+AGSnapshotHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 41DDC1771C4985250098190D /* FBSnapshotTestCase+AGSnapshotHelperTests.m */; };
+		41C3BE3C1FCF6BD0005422D8 /* UIApplication+PreferredContentSizeCategoryMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C3BE3B1FCF6BD0005422D8 /* UIApplication+PreferredContentSizeCategoryMockTests.swift */; };
 		660525BA1C09112000B5BF97 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 660525B91C09112000B5BF97 /* main.m */; };
 		660525BD1C09112000B5BF97 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 660525BC1C09112000B5BF97 /* AppDelegate.m */; };
 		660525C01C09112000B5BF97 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 660525BF1C09112000B5BF97 /* ViewController.m */; };
@@ -35,6 +36,8 @@
 		394AE5D97523A05453B9202D /* libPods-AGSnapshotHelperTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AGSnapshotHelperTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4144A6121D00CC4D009B134D /* AGSampleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGSampleView.h; sourceTree = "<group>"; };
 		4144A6131D00CC4D009B134D /* AGSampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGSampleView.m; sourceTree = "<group>"; };
+		41C3BE3A1FCF6BD0005422D8 /* AGSnapshotHelperTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AGSnapshotHelperTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		41C3BE3B1FCF6BD0005422D8 /* UIApplication+PreferredContentSizeCategoryMockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+PreferredContentSizeCategoryMockTests.swift"; sourceTree = "<group>"; };
 		41DDC1771C4985250098190D /* FBSnapshotTestCase+AGSnapshotHelperTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBSnapshotTestCase+AGSnapshotHelperTests.m"; sourceTree = "<group>"; };
 		660525B51C09112000B5BF97 /* AGSnapshotHelperTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AGSnapshotHelperTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		660525B81C09112000B5BF97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -147,9 +150,11 @@
 				66C7D4CC1C0226F4001C6546 /* Categories */,
 				665B9CFF1C0514F7000F292B /* AGPreferredContentSizeCategoryMockerTests.m */,
 				41DDC1771C4985250098190D /* FBSnapshotTestCase+AGSnapshotHelperTests.m */,
+				41C3BE3B1FCF6BD0005422D8 /* UIApplication+PreferredContentSizeCategoryMockTests.swift */,
 				4144A6121D00CC4D009B134D /* AGSampleView.h */,
 				4144A6131D00CC4D009B134D /* AGSampleView.m */,
 				730869FF1BF8E1E20033F34A /* Info.plist */,
+				41C3BE3A1FCF6BD0005422D8 /* AGSnapshotHelperTests-Bridging-Header.h */,
 			);
 			path = AGSnapshotHelperTests;
 			sourceTree = "<group>";
@@ -322,6 +327,7 @@
 			files = (
 				66C7D4CE1C022711001C6546 /* NSString+ContentSizeCategoryTests.m in Sources */,
 				415093CA1C498BD900F17144 /* FBSnapshotTestCase+AGSnapshotHelperTests.m in Sources */,
+				41C3BE3C1FCF6BD0005422D8 /* UIApplication+PreferredContentSizeCategoryMockTests.swift in Sources */,
 				4144A6141D00CC4D009B134D /* AGSampleView.m in Sources */,
 				665B9D001C0514F7000F292B /* AGPreferredContentSizeCategoryMockerTests.m in Sources */,
 			);
@@ -485,10 +491,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8D252BA2622CB50EC0BCE3C1 /* Pods-AGSnapshotHelperTests.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AGSnapshotHelperTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.allegro.AGSnapshotHelperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "AGSnapshotHelperTests/AGSnapshotHelperTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AGSnapshotHelperTestApp.app/AGSnapshotHelperTestApp";
 			};
@@ -498,10 +507,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 10CDCDF718D6988DFDCD3997 /* Pods-AGSnapshotHelperTests.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AGSnapshotHelperTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.allegro.AGSnapshotHelperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "AGSnapshotHelperTests/AGSnapshotHelperTests-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AGSnapshotHelperTestApp.app/AGSnapshotHelperTestApp";
 			};

--- a/Tests/AGSnapshotHelperTests/AGSnapshotHelperTests-Bridging-Header.h
+++ b/Tests/AGSnapshotHelperTests/AGSnapshotHelperTests-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import <AGSnapshotHelper/UIApplication+PreferredContentSizeCategoryMock.h>

--- a/Tests/AGSnapshotHelperTests/UIApplication+PreferredContentSizeCategoryMockTests.swift
+++ b/Tests/AGSnapshotHelperTests/UIApplication+PreferredContentSizeCategoryMockTests.swift
@@ -1,0 +1,38 @@
+//
+//  UIApplication+PreferredContentSizeCategoryMockTests.swift
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 29/11/2017.
+//  Copyright © 2017 allegro. All rights reserved.
+//
+
+import XCTest
+
+class UIApplication_PreferredContentSizeCategoryMockTests: XCTestCase {
+
+    func testUIApplicationPreferredContentSizeCategory_ShouldBeEqualToMockedContentSizeCategory_WhenMockedContentSizeCategoryIsSet() {
+        // Arrange
+        let application = UIApplication.shared
+        let contentSizeCategoryToMock = UIContentSizeCategory.extraSmall
+
+        // Act
+        application.mockedContentSizeCategory = contentSizeCategoryToMock
+
+        // Assert
+        XCTAssertEqual(application.preferredContentSizeCategory, contentSizeCategoryToMock)
+    }
+
+
+    func testUIApplicationPreferredContentSizeCategory_ShouldBeEqualToPreferredContentSizeCategory_WhenMockedContentSizeCategoryIsNil() {
+        // Arrange
+        let application = UIApplication.shared
+        let orginalContentSizeCategory = application.preferredContentSizeCategory
+        application.mockedContentSizeCategory = .accessibilityExtraExtraExtraLarge
+
+        // Act
+        application.mockedContentSizeCategory = nil
+
+        // Assert
+        XCTAssertEqual(application.preferredContentSizeCategory, orginalContentSizeCategory)
+    }
+}

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,9 +1,7 @@
 PODS:
   - AGSnapshotHelper (0.0.1):
     - FBSnapshotTestCase/Core (~> 2.0)
-    - OCMock (~> 3.2)
   - FBSnapshotTestCase/Core (2.1.4)
-  - OCMock (3.4)
 
 DEPENDENCIES:
   - AGSnapshotHelper (from `../AGSnapshotHelper.podspec`)
@@ -13,9 +11,8 @@ EXTERNAL SOURCES:
     :path: ../AGSnapshotHelper.podspec
 
 SPEC CHECKSUMS:
-  AGSnapshotHelper: 5e102a001e422401437038947ce6260960a2d8c3
+  AGSnapshotHelper: 760d9736f4db590193f421f0ab21087fcfe8170b
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
 
 PODFILE CHECKSUM: 130d35b51c57f50125c9de06f56eee808d5102eb
 


### PR DESCRIPTION
OCMock is used only for simple swizzling. There's no need to get whole library for this case.