### PR TITLE
Add mock protocols and view mocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 
-osx_image: xcode8.3
+osx_image: xcode9.2
 
 env:
 global:

--- a/Pod/Classes/Categories/UITraitCollection+ViewMockable.swift
+++ b/Pod/Classes/Categories/UITraitCollection+ViewMockable.swift
@@ -1,0 +1,30 @@
+//
+//  UITraitCollection+ViewMockable.swift
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 05/05/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UITraitCollection {
+    
+    convenience init(mockParameters: ViewMockable) {
+        var newTraitCollection: [UITraitCollection] = [
+            UITraitCollection(verticalSizeClass: mockParameters.verticalSizeClass),
+            UITraitCollection(horizontalSizeClass: mockParameters.horizontalSizeClass)
+        ]
+        
+        if #available(iOS 10.0, *) {
+            newTraitCollection.append(UITraitCollection(layoutDirection: mockParameters.layoutDirection))
+            
+            if let mockedPreferredContentSizeCategory = mockParameters.preferredContentSizeCategory {
+                newTraitCollection.append(UITraitCollection(preferredContentSizeCategory: mockedPreferredContentSizeCategory))
+            }
+        }
+        
+        self.init(traitsFrom: newTraitCollection)
+    }
+}

--- a/Pod/Classes/Mocking/DeviceMockable.swift
+++ b/Pod/Classes/Mocking/DeviceMockable.swift
@@ -1,0 +1,24 @@
+//
+//  DeviceMockable.swift
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 06/03/2018.
+//
+
+import Foundation
+import UIKit
+
+/// A set of properties that provide information about device.
+@objc(AGDeviceMockable)
+public protocol DeviceMockable {
+    
+    /// Device name.
+    var name: String { get set }
+    
+    /// Interface orientation to stub.
+    var orientation: UIInterfaceOrientation { get set }
+    
+    /// User interface idiom to stub. Part of trait collection.
+    var userInterfaceIdiom: UIUserInterfaceIdiom { get set }
+}
+

--- a/Pod/Classes/Mocking/DeviceMockable.swift
+++ b/Pod/Classes/Mocking/DeviceMockable.swift
@@ -3,6 +3,7 @@
 //  AGSnapshotHelper
 //
 //  Created by Adam Grzegorowski on 06/03/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
 //
 
 import Foundation

--- a/Pod/Classes/Mocking/MockingDeviceView.swift
+++ b/Pod/Classes/Mocking/MockingDeviceView.swift
@@ -24,7 +24,7 @@ public class MockingDeviceView: UIView {
     /// Object storing properties to stub.
     public var mockParameters: DeviceViewMockable? {
         didSet {
-            guard let mockParameters = mockParameters  else {
+            guard let mockParameters = mockParameters else {
                 return
             }
             
@@ -61,28 +61,15 @@ public class MockingDeviceView: UIView {
     }
     
     override public var traitCollection: UITraitCollection {
-        var mockedTraitCollection: [UITraitCollection] = [super.traitCollection]
-        
-        if let mockedVerticalSizeClass = mockParameters?.verticalSizeClass {
-            mockedTraitCollection.append(UITraitCollection(verticalSizeClass: mockedVerticalSizeClass))
+        guard let mockParameters = mockParameters else {
+            return super.traitCollection
         }
-        if let mockedHorizontalSizeClass = mockParameters?.horizontalSizeClass {
-            mockedTraitCollection.append(UITraitCollection(horizontalSizeClass: mockedHorizontalSizeClass))
-        }
-        if #available(iOS 10.0, *) {
-            if let mockedPreferredContentSizeCategory = mockParameters?.preferredContentSizeCategory {
-                mockedTraitCollection.append(UITraitCollection(preferredContentSizeCategory: mockedPreferredContentSizeCategory))
-            }
-            
-            if let mockedLayoutDirection = mockParameters?.layoutDirection {
-                mockedTraitCollection.append(UITraitCollection(layoutDirection: mockedLayoutDirection))
-            }
-        }
-        if let userInterfaceIdiom = mockParameters?.userInterfaceIdiom {
-            mockedTraitCollection.append(UITraitCollection(userInterfaceIdiom: userInterfaceIdiom))
-        }
-        
-        return UITraitCollection(traitsFrom: mockedTraitCollection)
+
+        return UITraitCollection(traitsFrom: [
+            super.traitCollection,
+            .init(mockParameters: mockParameters),
+            .init(userInterfaceIdiom: mockParameters.userInterfaceIdiom)
+        ])
     }
     
     // MARK: - Private methods

--- a/Pod/Classes/Mocking/MockingDeviceView.swift
+++ b/Pod/Classes/Mocking/MockingDeviceView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 public typealias DeviceViewMockable = ViewMockable & DeviceMockable
 
-/// View stubing layout defining properties and information about device.
+/// View stubbing layout defining properties and information about device.
 /// Some of layout properties (e.g. `safeAreaInsets`, or `traitCollection`) are read-only,
 /// so this view can be used as container which helps to force custom layout.
 /// Additionally `mockParameters` contains information about mocked device,

--- a/Pod/Classes/Mocking/MockingDeviceView.swift
+++ b/Pod/Classes/Mocking/MockingDeviceView.swift
@@ -1,0 +1,102 @@
+//
+//  MockingDeviceView.swift
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 10/03/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public typealias DeviceViewMockable = ViewMockable & DeviceMockable
+
+/// View stubing layout defining properties and information about device.
+/// Some of layout properties (e.g. `safeAreaInsets`, or `traitCollection`) are read-only,
+/// so this view can be used as container which helps to force custom layout.
+/// Additionally `mockParameters` contains information about mocked device,
+/// which can be use to distinguish interface orientation or device model.
+@objc(AGMockingDeviceView)
+public class MockingDeviceView: UIView {
+    
+    // MARK: - Public methods
+    
+    /// Object storing properties to stub.
+    public var mockParameters: DeviceViewMockable? {
+        didSet {
+            guard let mockParameters = mockParameters  else {
+                return
+            }
+            
+            frame.size = mockParameters.size
+            setUpLayoutMargins()
+        }
+    }
+    
+    /// Initializes and returns a newly allocated view object with rectangle frame equal to 0,0 origin and `mockParameters.size` size.
+    ///
+    /// - Parameter mockParameters: Object with properties to stub.
+    public init(mockParameters: DeviceViewMockable) {
+        let newFrame = CGRect(origin: .zero, size: mockParameters.size)
+        super.init(frame: newFrame)
+    }
+    
+    // MARK: - Overriden methods
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUpLayoutMargins()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        setUpLayoutMargins()
+    }
+    
+    @available(iOS 11.0, *)
+    override public var safeAreaInsets: UIEdgeInsets {
+        return mockParameters?.safeAreaInsets ?? super.safeAreaInsets
+    }
+    
+    override public var traitCollection: UITraitCollection {
+        var mockedTraitCollection: [UITraitCollection] = [super.traitCollection]
+        
+        if let mockedVerticalSizeClass = mockParameters?.verticalSizeClass {
+            mockedTraitCollection.append(UITraitCollection(verticalSizeClass: mockedVerticalSizeClass))
+        }
+        if let mockedHorizontalSizeClass = mockParameters?.horizontalSizeClass {
+            mockedTraitCollection.append(UITraitCollection(horizontalSizeClass: mockedHorizontalSizeClass))
+        }
+        if #available(iOS 10.0, *) {
+            if let mockedPreferredContentSizeCategory = mockParameters?.preferredContentSizeCategory {
+                mockedTraitCollection.append(UITraitCollection(preferredContentSizeCategory: mockedPreferredContentSizeCategory))
+            }
+            
+            if let mockedLayoutDirection = mockParameters?.layoutDirection {
+                mockedTraitCollection.append(UITraitCollection(layoutDirection: mockedLayoutDirection))
+            }
+        }
+        if let userInterfaceIdiom = mockParameters?.userInterfaceIdiom {
+            mockedTraitCollection.append(UITraitCollection(userInterfaceIdiom: userInterfaceIdiom))
+        }
+        
+        return UITraitCollection(traitsFrom: mockedTraitCollection)
+    }
+    
+    // MARK: - Private methods
+    
+    private func setUpLayoutMargins() {
+        
+        if #available(iOS 11.0, *) {
+            if let mockedDirectionalLayoutMargins = mockParameters?.directionalLayoutMargins {
+                directionalLayoutMargins = mockedDirectionalLayoutMargins
+            }
+        }
+        
+        if let mockedLayoutMargins = mockParameters?.layoutMargins {
+            layoutMargins = mockedLayoutMargins
+        }
+    }
+}

--- a/Pod/Classes/Mocking/MockingView.swift
+++ b/Pod/Classes/Mocking/MockingView.swift
@@ -1,0 +1,95 @@
+//
+//  MockingView.swift
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 22/02/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// View stubing layout defining properties.
+/// Some of layout properties (e.g. `safeAreaInsets`, or `traitCollection`) are read-only,
+/// so this view can be used as container which helps to force custom layout.
+@objc(AGMockingView)
+public class MockingView: UIView {
+    
+    // MARK: - Public methods
+
+    /// Object storing properties to stub.
+    public var mockParameters: ViewMockable? {
+        didSet {
+            guard let mockParameters = mockParameters  else {
+                return
+            }
+            
+            frame.size = mockParameters.size
+            setUpLayoutMargins()
+        }
+    }
+    
+    /// Initializes and returns a newly allocated view object with rectangle frame equal to 0,0 origin and `mockParameters.size` size.
+    ///
+    /// - Parameter mockParameters: Object with properties to stub.
+    public init(mockParameters: ViewMockable) {
+        let newFrame = CGRect(origin: .zero, size: mockParameters.size)
+        super.init(frame: newFrame)
+    }
+    
+    // MARK: - Overriden methods
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUpLayoutMargins()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        setUpLayoutMargins()
+    }
+    
+    @available(iOS 11.0, *)
+    override public var safeAreaInsets: UIEdgeInsets {
+        return mockParameters?.safeAreaInsets ?? super.safeAreaInsets
+    }
+    
+    override public var traitCollection: UITraitCollection {
+        var mockedTraitCollection: [UITraitCollection] = [super.traitCollection]
+
+        if let mockedVerticalSizeClass = mockParameters?.verticalSizeClass {
+            mockedTraitCollection.append(UITraitCollection(verticalSizeClass: mockedVerticalSizeClass))
+        }
+        if let mockedHorizontalSizeClass = mockParameters?.horizontalSizeClass {
+            mockedTraitCollection.append(UITraitCollection(horizontalSizeClass: mockedHorizontalSizeClass))
+        }
+        if #available(iOS 10.0, *) {
+            if let mockedPreferredContentSizeCategory = mockParameters?.preferredContentSizeCategory {
+                mockedTraitCollection.append(UITraitCollection(preferredContentSizeCategory: mockedPreferredContentSizeCategory))
+            }
+            
+            if let mockedLayoutDirection = mockParameters?.layoutDirection {
+                mockedTraitCollection.append(UITraitCollection(layoutDirection: mockedLayoutDirection))
+            }
+        }
+        
+        return UITraitCollection(traitsFrom: mockedTraitCollection)
+    }
+    
+    // MARK: - Private methods
+    
+    private func setUpLayoutMargins() {
+
+        if let mockedLayoutMargins = mockParameters?.layoutMargins {
+            layoutMargins = mockedLayoutMargins
+        }
+
+        if #available(iOS 11.0, *) {
+            if let mockedDirectionalLayoutMargins = mockParameters?.directionalLayoutMargins {
+                directionalLayoutMargins = mockedDirectionalLayoutMargins
+            }
+        }
+    }
+}

--- a/Pod/Classes/Mocking/MockingView.swift
+++ b/Pod/Classes/Mocking/MockingView.swift
@@ -20,7 +20,7 @@ public class MockingView: UIView {
     /// Object storing properties to stub.
     public var mockParameters: ViewMockable? {
         didSet {
-            guard let mockParameters = mockParameters  else {
+            guard let mockParameters = mockParameters else {
                 return
             }
             
@@ -57,25 +57,15 @@ public class MockingView: UIView {
     }
     
     override public var traitCollection: UITraitCollection {
-        var mockedTraitCollection: [UITraitCollection] = [super.traitCollection]
-
-        if let mockedVerticalSizeClass = mockParameters?.verticalSizeClass {
-            mockedTraitCollection.append(UITraitCollection(verticalSizeClass: mockedVerticalSizeClass))
-        }
-        if let mockedHorizontalSizeClass = mockParameters?.horizontalSizeClass {
-            mockedTraitCollection.append(UITraitCollection(horizontalSizeClass: mockedHorizontalSizeClass))
-        }
-        if #available(iOS 10.0, *) {
-            if let mockedPreferredContentSizeCategory = mockParameters?.preferredContentSizeCategory {
-                mockedTraitCollection.append(UITraitCollection(preferredContentSizeCategory: mockedPreferredContentSizeCategory))
-            }
-            
-            if let mockedLayoutDirection = mockParameters?.layoutDirection {
-                mockedTraitCollection.append(UITraitCollection(layoutDirection: mockedLayoutDirection))
-            }
+        guard let mockParameters = mockParameters else {
+            return super.traitCollection
         }
         
-        return UITraitCollection(traitsFrom: mockedTraitCollection)
+        return UITraitCollection(traitsFrom: [
+            super.traitCollection,
+            .init(mockParameters: mockParameters),
+        ])
+
     }
     
     // MARK: - Private methods

--- a/Pod/Classes/Mocking/MockingView.swift
+++ b/Pod/Classes/Mocking/MockingView.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-/// View stubing layout defining properties.
+/// View stubbing layout defining properties.
 /// Some of layout properties (e.g. `safeAreaInsets`, or `traitCollection`) are read-only,
 /// so this view can be used as container which helps to force custom layout.
 @objc(AGMockingView)

--- a/Pod/Classes/Mocking/ViewMockable.swift
+++ b/Pod/Classes/Mocking/ViewMockable.swift
@@ -1,0 +1,43 @@
+//
+//  ViewMockable.swift
+//  AGSnapshotHelper
+//
+//  Created by Adam Grzegorowski on 22/02/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// A set of properties that provide information about layout of view.
+@objc(AGViewMockable)
+public protocol ViewMockable {
+    
+    /// Size to stub
+    var size: CGSize { get set }
+    
+    /// Safe area insets to stub.
+    var safeAreaInsets: UIEdgeInsets { get set }
+    
+    /// Layout margins insets to stub.
+    /// In iOS 11 and later use the `directionalLayoutMargins`.
+    var layoutMargins: UIEdgeInsets { get set }
+    
+    /// Directional layout margins insets to stub.
+    @available(iOS 11.0, *)
+    var directionalLayoutMargins: NSDirectionalEdgeInsets { get set }
+    
+    /// Horizontal size class to stub. Part of trait collection.
+    var horizontalSizeClass: UIUserInterfaceSizeClass { get set }
+    
+    /// Vertical size class to stub. Part of trait collection.
+    var verticalSizeClass: UIUserInterfaceSizeClass { get set }
+    
+    /// Preferred content size category to stub. Part of trait collection.
+    @available(iOS 10.0, *)
+    var preferredContentSizeCategory: UIContentSizeCategory? { get set }
+    
+    /// Layout direction to stub. Part of trait collection.
+    @available(iOS 10.0, *)
+    var layoutDirection: UITraitEnvironmentLayoutDirection { get set }
+}

--- a/Tests/AGSnapshotHelper.xcodeproj/project.pbxproj
+++ b/Tests/AGSnapshotHelper.xcodeproj/project.pbxproj
@@ -8,10 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		001744F1D98E90B4451755FF /* Pods_AGSnapshotHelperTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5CE19F12645FEA3BD48CB44 /* Pods_AGSnapshotHelperTests.framework */; };
+		4123DEC3205453C100C04589 /* AGViewMockParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 4123DEC1205453C000C04589 /* AGViewMockParameters.m */; };
 		4144A6141D00CC4D009B134D /* AGSampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4144A6131D00CC4D009B134D /* AGSampleView.m */; };
 		414FC4382014E749006BE631 /* NotificationCenter+PostContentSizeCategoryChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414FC4372014E749006BE631 /* NotificationCenter+PostContentSizeCategoryChangeTests.swift */; };
 		415093CA1C498BD900F17144 /* FBSnapshotTestCase+AGSnapshotHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 41DDC1771C4985250098190D /* FBSnapshotTestCase+AGSnapshotHelperTests.m */; };
+		41D5CE3C204F29AD00CDFD67 /* MockingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D5CE3B204F29AD00CDFD67 /* MockingViewTests.swift */; };
+		41D5CE3E204F319100CDFD67 /* NSDirectionalEdgeInsets+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D5CE3D204F319100CDFD67 /* NSDirectionalEdgeInsets+Equatable.swift */; };
 		41D6DE781FD8987000EAED6E /* UIApplication+PreferredContentSizeCategoryMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D6DE771FD8987000EAED6E /* UIApplication+PreferredContentSizeCategoryMockTests.swift */; };
+		41E5497220545FC800D85E05 /* AGDeviceViewMockParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 41E5497120545FC800D85E05 /* AGDeviceViewMockParameters.m */; };
+		41E549742054668C00D85E05 /* MockingDeviceViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E549732054668C00D85E05 /* MockingDeviceViewTests.swift */; };
 		660525BA1C09112000B5BF97 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 660525B91C09112000B5BF97 /* main.m */; };
 		660525BD1C09112000B5BF97 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 660525BC1C09112000B5BF97 /* AppDelegate.m */; };
 		660525C01C09112000B5BF97 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 660525BF1C09112000B5BF97 /* ViewController.m */; };
@@ -32,12 +37,19 @@
 
 /* Begin PBXFileReference section */
 		10CDCDF718D6988DFDCD3997 /* Pods-AGSnapshotHelperTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AGSnapshotHelperTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AGSnapshotHelperTests/Pods-AGSnapshotHelperTests.release.xcconfig"; sourceTree = "<group>"; };
+		4123DEC1205453C000C04589 /* AGViewMockParameters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGViewMockParameters.m; sourceTree = "<group>"; };
+		4123DEC2205453C100C04589 /* AGViewMockParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGViewMockParameters.h; sourceTree = "<group>"; };
 		4144A6121D00CC4D009B134D /* AGSampleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGSampleView.h; sourceTree = "<group>"; };
 		4144A6131D00CC4D009B134D /* AGSampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AGSampleView.m; sourceTree = "<group>"; };
 		414FC4372014E749006BE631 /* NotificationCenter+PostContentSizeCategoryChangeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+PostContentSizeCategoryChangeTests.swift"; sourceTree = "<group>"; };
+		41D5CE3B204F29AD00CDFD67 /* MockingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockingViewTests.swift; sourceTree = "<group>"; };
+		41D5CE3D204F319100CDFD67 /* NSDirectionalEdgeInsets+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDirectionalEdgeInsets+Equatable.swift"; sourceTree = "<group>"; };
 		41D6DE771FD8987000EAED6E /* UIApplication+PreferredContentSizeCategoryMockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+PreferredContentSizeCategoryMockTests.swift"; sourceTree = "<group>"; };
 		41D6DE791FD8989500EAED6E /* AGSnapshotHelperTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AGSnapshotHelperTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		41DDC1771C4985250098190D /* FBSnapshotTestCase+AGSnapshotHelperTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBSnapshotTestCase+AGSnapshotHelperTests.m"; sourceTree = "<group>"; };
+		41E5497020545FC800D85E05 /* AGDeviceViewMockParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AGDeviceViewMockParameters.h; sourceTree = "<group>"; };
+		41E5497120545FC800D85E05 /* AGDeviceViewMockParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AGDeviceViewMockParameters.m; sourceTree = "<group>"; };
+		41E549732054668C00D85E05 /* MockingDeviceViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockingDeviceViewTests.swift; sourceTree = "<group>"; };
 		660525B51C09112000B5BF97 /* AGSnapshotHelperTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AGSnapshotHelperTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		660525B81C09112000B5BF97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		660525B91C09112000B5BF97 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -80,6 +92,19 @@
 				10CDCDF718D6988DFDCD3997 /* Pods-AGSnapshotHelperTests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		41D5CE38204F298200CDFD67 /* Mocking */ = {
+			isa = PBXGroup;
+			children = (
+				41D5CE3B204F29AD00CDFD67 /* MockingViewTests.swift */,
+				41E549732054668C00D85E05 /* MockingDeviceViewTests.swift */,
+				41E5497020545FC800D85E05 /* AGDeviceViewMockParameters.h */,
+				41E5497120545FC800D85E05 /* AGDeviceViewMockParameters.m */,
+				4123DEC2205453C100C04589 /* AGViewMockParameters.h */,
+				4123DEC1205453C000C04589 /* AGViewMockParameters.m */,
+			);
+			path = Mocking;
 			sourceTree = "<group>";
 		};
 		4F61E30CF0A630D2526319F1 /* Frameworks */ = {
@@ -147,10 +172,12 @@
 			isa = PBXGroup;
 			children = (
 				66C7D4CC1C0226F4001C6546 /* Categories */,
+				41D5CE38204F298200CDFD67 /* Mocking */,
 				41DDC1771C4985250098190D /* FBSnapshotTestCase+AGSnapshotHelperTests.m */,
 				4144A6121D00CC4D009B134D /* AGSampleView.h */,
 				4144A6131D00CC4D009B134D /* AGSampleView.m */,
 				41D6DE791FD8989500EAED6E /* AGSnapshotHelperTests-Bridging-Header.h */,
+				41D5CE3D204F319100CDFD67 /* NSDirectionalEdgeInsets+Equatable.swift */,
 				730869FF1BF8E1E20033F34A /* Info.plist */,
 			);
 			path = AGSnapshotHelperTests;
@@ -327,8 +354,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				41E549742054668C00D85E05 /* MockingDeviceViewTests.swift in Sources */,
 				414FC4382014E749006BE631 /* NotificationCenter+PostContentSizeCategoryChangeTests.swift in Sources */,
+				41D5CE3E204F319100CDFD67 /* NSDirectionalEdgeInsets+Equatable.swift in Sources */,
+				41D5CE3C204F29AD00CDFD67 /* MockingViewTests.swift in Sources */,
 				41D6DE781FD8987000EAED6E /* UIApplication+PreferredContentSizeCategoryMockTests.swift in Sources */,
+				4123DEC3205453C100C04589 /* AGViewMockParameters.m in Sources */,
+				41E5497220545FC800D85E05 /* AGDeviceViewMockParameters.m in Sources */,
 				415093CA1C498BD900F17144 /* FBSnapshotTestCase+AGSnapshotHelperTests.m in Sources */,
 				4144A6141D00CC4D009B134D /* AGSampleView.m in Sources */,
 			);

--- a/Tests/AGSnapshotHelperTests/AGSnapshotHelperTests-Bridging-Header.h
+++ b/Tests/AGSnapshotHelperTests/AGSnapshotHelperTests-Bridging-Header.h
@@ -2,4 +2,5 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <AGSnapshotHelper/UIApplication+PreferredContentSizeCategoryMock.h>
+#import "AGDeviceViewMockParameters.h"
+#import "AGViewMockParameters.h"

--- a/Tests/AGSnapshotHelperTests/Mocking/AGDeviceViewMockParameters.h
+++ b/Tests/AGSnapshotHelperTests/Mocking/AGDeviceViewMockParameters.h
@@ -1,0 +1,33 @@
+//
+//  AGDeviceViewMockParameters.h
+//  AGSnapshotHelperTests
+//
+//  Created by Adam Grzegorowski on 10/03/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+@import AGSnapshotHelper;
+@import Foundation;
+@import UIKit;
+
+// Swift does not allow to mark stored properties with @available() atribute,
+// so use Objective-C which works fine.
+NS_SWIFT_NAME(DeviceViewMockParameters)
+@interface AGDeviceViewMockParameters : NSObject<AGDeviceMockable, AGViewMockable>
+
+// AGDeviceMockable
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, assign) UIInterfaceOrientation orientation;
+@property (nonatomic, assign) UIUserInterfaceIdiom userInterfaceIdiom;
+
+// AGViewMockable
+@property (nonatomic, assign) CGSize size;
+@property (nonatomic, assign) UIEdgeInsets safeAreaInsets;
+@property (nonatomic, assign) UIEdgeInsets layoutMargins;
+@property (nonatomic, assign) UIUserInterfaceSizeClass horizontalSizeClass;
+@property (nonatomic, assign) UIUserInterfaceSizeClass verticalSizeClass;
+@property (nonatomic, strong) UIContentSizeCategory preferredContentSizeCategory NS_AVAILABLE_IOS(10.0);
+@property (nonatomic, assign) UITraitEnvironmentLayoutDirection layoutDirection NS_AVAILABLE_IOS(10.0);
+@property (nonatomic, assign) NSDirectionalEdgeInsets directionalLayoutMargins NS_AVAILABLE_IOS(11.0);
+
+@end

--- a/Tests/AGSnapshotHelperTests/Mocking/AGDeviceViewMockParameters.m
+++ b/Tests/AGSnapshotHelperTests/Mocking/AGDeviceViewMockParameters.m
@@ -1,0 +1,12 @@
+//
+//  AGDeviceViewMockParameters.m
+//  AGSnapshotHelperTests
+//
+//  Created by Adam Grzegorowski on 10/03/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+#import "AGDeviceViewMockParameters.h"
+
+@implementation AGDeviceViewMockParameters
+@end

--- a/Tests/AGSnapshotHelperTests/Mocking/AGViewMockParameters.h
+++ b/Tests/AGSnapshotHelperTests/Mocking/AGViewMockParameters.h
@@ -1,0 +1,26 @@
+//
+//  AGViewMockParameters.h
+//  AGSnapshotHelperTests
+//
+//  Created by Adam Grzegorowski on 07/03/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+@import UIKit;
+@import AGSnapshotHelper;
+
+// Swift does not allow to mark stored properties with @available() atribute,
+// so use Objective-C which works fine.
+NS_SWIFT_NAME(ViewMockParameters)
+@interface AGViewMockParameters : NSObject<AGViewMockable>
+
+@property (nonatomic, assign) CGSize size;
+@property (nonatomic, assign) UIEdgeInsets safeAreaInsets;
+@property (nonatomic, assign) UIEdgeInsets layoutMargins;
+@property (nonatomic, assign) UIUserInterfaceSizeClass horizontalSizeClass;
+@property (nonatomic, assign) UIUserInterfaceSizeClass verticalSizeClass;
+@property (nonatomic, strong) UIContentSizeCategory preferredContentSizeCategory NS_AVAILABLE_IOS(10.0);
+@property (nonatomic, assign) UITraitEnvironmentLayoutDirection layoutDirection NS_AVAILABLE_IOS(10.0);
+@property (nonatomic, assign) NSDirectionalEdgeInsets directionalLayoutMargins NS_AVAILABLE_IOS(11.0);
+
+@end

--- a/Tests/AGSnapshotHelperTests/Mocking/AGViewMockParameters.m
+++ b/Tests/AGSnapshotHelperTests/Mocking/AGViewMockParameters.m
@@ -1,0 +1,12 @@
+//
+//  AGViewMockParameters.m
+//  AGSnapshotHelperTests
+//
+//  Created by Adam Grzegorowski on 07/03/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+#import "AGViewMockParameters.h"
+
+@implementation AGViewMockParameters
+@end

--- a/Tests/AGSnapshotHelperTests/Mocking/MockingDeviceViewTests.swift
+++ b/Tests/AGSnapshotHelperTests/Mocking/MockingDeviceViewTests.swift
@@ -1,0 +1,159 @@
+//
+//  MockingDeviceViewTests.swift
+//  AGSnapshotHelperTests
+//
+//  Created by Adam Grzegorowski on 10/03/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+import AGSnapshotHelper
+import XCTest
+
+class MockingDeviceViewTests: XCTestCase {
+    
+    // MARK: - AGDeviceMockable
+    
+    func testMockingDeviceViewUserInterfaceIdiom_ShouldBeEqualToDeviceViewMockableUserInterfaceIdiom() {
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.userInterfaceIdiom = .phone
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = deviceViewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(userInterfaceIdiom: .phone)))
+    }
+    
+    // MARK: - AGViewMockable
+    
+    func testMockingDeviceViewSize_ShouldBeEqualToViewMockableSize() {
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.size = CGSize(width: 20, height: 10)
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let size = deviceViewMock.frame.size
+        
+        // Assert
+        XCTAssertEqual(size, CGSize(width: 20, height: 10))
+    }
+    
+    func testMockingDeviceViewSafeAreaInsets_ShouldBeEqualToDeviceViewMockableSafeAreaInsets() {
+        guard #available(iOS 11.0, *) else {
+            return
+        }
+        
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.safeAreaInsets = UIEdgeInsets(top: 5.0, left: 10.0, bottom: 15.0, right: 20.0)
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let safeAreaInsets = deviceViewMock.safeAreaInsets
+        
+        // Assert
+        XCTAssertEqual(safeAreaInsets, UIEdgeInsets(top: 5.0, left: 10.0, bottom: 15.0, right: 20.0))
+    }
+    
+    func testMockingDeviceViewLayoutMargins_ShouldBeEqualToDeviceViewMockableLayoutMargins() {
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.layoutMargins = UIEdgeInsets(top: 1.0, left: 2.0, bottom: 3.0, right: 4.0)
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let layoutMargins = deviceViewMock.layoutMargins
+        
+        // Assert
+        XCTAssertEqual(layoutMargins, UIEdgeInsets(top: 1.0, left: 2.0, bottom: 3.0, right: 4.0))
+    }
+    
+    func testMockingDeviceViewDirectionalLayoutMargins_ShouldBeEqualToDeviceViewMockableDirectionalLayoutMargins() {
+        guard #available(iOS 11.0, *) else {
+            return
+        }
+        
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 4.0, leading: 3.0, bottom: 2.0, trailing: 1.0)
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let directionalLayoutMargins = deviceViewMock.directionalLayoutMargins
+        
+        // Assert
+        XCTAssertEqual(directionalLayoutMargins, NSDirectionalEdgeInsets(top: 4.0, leading: 3.0, bottom: 2.0, trailing: 1.0))
+    }
+    
+    func testMockingDeviceViewTraitCollection_ShouldContainPreferredContentSizeCategoryEqualToMockParameters_WhenDeviceViewMockParametersSetsPreferredContentSizeCategory() {
+        guard #available(iOS 10.0, *) else {
+            return
+        }
+        
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.preferredContentSizeCategory = .accessibilityExtraLarge
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = deviceViewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(preferredContentSizeCategory: .accessibilityExtraLarge)))
+    }
+    
+    func testMockingDeviceViewTraitCollection_ShouldContainHorizontalSizeClassEqualToMockParameters_WhenDeviceViewMockParametersSetsHorizontalSizeClass() {
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.horizontalSizeClass = .compact
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = deviceViewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(horizontalSizeClass: .compact)))
+    }
+    
+    func testMockingDeviceViewTraitCollection_ShouldContainVerticalSizeClassEqualToMockParameters_WhenDeviceViewMockParametersSetsVerticalSizeClass() {
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.verticalSizeClass = .regular
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = deviceViewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(verticalSizeClass: .regular)))
+    }
+    
+    func testMockingDeviceViewTraitCollection_ShouldContainLayoutDirectionEqualToMockParameters_WhenDeviceViewMockParametersSetsLayoutDirection() {
+        guard #available(iOS 10.0, *) else {
+            return
+        }
+        
+        // Arrange
+        let mockParameters = DeviceViewMockParameters()
+        mockParameters.layoutDirection = .rightToLeft
+        let deviceViewMock = MockingDeviceView()
+        deviceViewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = deviceViewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(layoutDirection: .rightToLeft)))
+    }
+}

--- a/Tests/AGSnapshotHelperTests/Mocking/MockingViewTests.swift
+++ b/Tests/AGSnapshotHelperTests/Mocking/MockingViewTests.swift
@@ -1,0 +1,141 @@
+//
+//  MockingViewTests.swift
+//  AGSnapshotHelperTests
+//
+//  Created by Adam Grzegorowski on 06/03/2018.
+//  Copyright © 2018 Allegro Group. All rights reserved.
+//
+
+import AGSnapshotHelper
+import XCTest
+
+class MockingViewTests: XCTestCase {
+    
+    func testMockingViewSize_ShouldBeEqualToViewMockableSize() {
+        // Arrange
+        let mockParameters = ViewMockParameters()
+        mockParameters.size = CGSize(width: 20, height: 10)
+        let viewMock = MockingView()
+        viewMock.mockParameters = mockParameters
+        
+        // Act
+        let size = viewMock.frame.size
+        
+        // Assert
+        XCTAssertEqual(size, CGSize(width: 20, height: 10))
+    }
+
+    func testMockingViewSafeAreaInsets_ShouldBeEqualToViewMockableSafeAreaInsets() {
+        guard #available(iOS 11.0, *) else {
+            return
+        }
+
+        // Arrange
+        let mockParameters = ViewMockParameters()
+        mockParameters.safeAreaInsets = UIEdgeInsets(top: 5.0, left: 10.0, bottom: 15.0, right: 20.0)
+        let viewMock = MockingView()
+        viewMock.mockParameters = mockParameters
+        
+        // Act
+        let safeAreaInsets = viewMock.safeAreaInsets
+        
+        // Assert
+        XCTAssertEqual(safeAreaInsets, UIEdgeInsets(top: 5.0, left: 10.0, bottom: 15.0, right: 20.0))
+    }
+    
+    func testMockingViewLayoutMargins_ShouldBeEqualToViewMockableLayoutMargins() {
+        // Arrange
+        let mockParameters = ViewMockParameters()
+        mockParameters.layoutMargins = UIEdgeInsets(top: 1.0, left: 2.0, bottom: 3.0, right: 4.0)
+        let viewMock = MockingView()
+        viewMock.mockParameters = mockParameters
+        
+        // Act
+        let layoutMargins = viewMock.layoutMargins
+        
+        // Assert
+        XCTAssertEqual(layoutMargins, UIEdgeInsets(top: 1.0, left: 2.0, bottom: 3.0, right: 4.0))
+    }
+    
+    func testMockingViewDirectionalLayoutMargins_ShouldBeEqualToViewMockableDirectionalLayoutMargins() {
+        guard #available(iOS 11.0, *) else {
+            return
+        }
+
+        // Arrange
+        let mockParameters = ViewMockParameters()
+        mockParameters.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 4.0, leading: 3.0, bottom: 2.0, trailing: 1.0)
+        let viewMock = MockingView()
+        viewMock.mockParameters = mockParameters
+        
+        // Act
+        let directionalLayoutMargins = viewMock.directionalLayoutMargins
+        
+        // Assert
+        XCTAssertEqual(directionalLayoutMargins, NSDirectionalEdgeInsets(top: 4.0, leading: 3.0, bottom: 2.0, trailing: 1.0))
+    }
+    
+    func testMockingViewTraitCollection_ShouldContainPreferredContentSizeCategoryEqualToMockParameters_WhenViewMockParametersSetsPreferredContentSizeCategory() {
+        guard #available(iOS 10.0, *) else {
+            return
+        }
+
+        // Arrange
+        let mockParameters = ViewMockParameters()
+        mockParameters.preferredContentSizeCategory = .accessibilityExtraLarge
+        let viewMock = MockingView()
+        viewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = viewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(preferredContentSizeCategory: .accessibilityExtraLarge)))
+    }
+    
+    func testMockingViewTraitCollection_ShouldContainHorizontalSizeClassEqualToMockParameters_WhenViewMockParametersSetsHorizontalSizeClass() {
+        // Arrange
+        let mockParameters = ViewMockParameters()
+        mockParameters.horizontalSizeClass = .compact
+        let viewMock = MockingView()
+        viewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = viewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(horizontalSizeClass: .compact)))
+    }
+    
+    func testMockingViewTraitCollection_ShouldContainVerticalSizeClassEqualToMockParameters_WhenViewMockParametersSetsVerticalSizeClass() {
+        // Arrange
+        let mockParameters = ViewMockParameters()
+        mockParameters.verticalSizeClass = .regular
+        let viewMock = MockingView()
+        viewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = viewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(verticalSizeClass: .regular)))
+    }
+    
+    func testMockingViewTraitCollection_ShouldContainLayoutDirectionEqualToMockParameters_WhenViewMockParametersSetsLayoutDirection() {
+        guard #available(iOS 10.0, *) else {
+            return
+        }
+
+        // Arrange
+        let mockParameters = ViewMockParameters()
+        mockParameters.layoutDirection = .rightToLeft
+        let viewMock = MockingView()
+        viewMock.mockParameters = mockParameters
+        
+        // Act
+        let traitCollection = viewMock.traitCollection
+        
+        // Assert
+        XCTAssertTrue(traitCollection.containsTraits(in: .init(layoutDirection: .rightToLeft)))
+    }
+}

--- a/Tests/AGSnapshotHelperTests/NSDirectionalEdgeInsets+Equatable.swift
+++ b/Tests/AGSnapshotHelperTests/NSDirectionalEdgeInsets+Equatable.swift
@@ -1,0 +1,16 @@
+//
+//  NSDirectionalEdgeInsets+Equatable.swift
+//  AGSnapshotHelperTests
+//
+//  Created by Adam Grzegorowski on 06/03/2018.
+//  Copyright © 2018 allegro. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 11.0, *)
+extension NSDirectionalEdgeInsets: Equatable {
+    public static func ==(lhs: NSDirectionalEdgeInsets, rhs: NSDirectionalEdgeInsets) -> Bool {
+        return lhs.top == rhs.top && lhs.leading == rhs.leading && lhs.bottom == rhs.bottom && lhs.trailing == rhs.trailing
+    }
+}


### PR DESCRIPTION
# WHAT:
- add mock protocols
- add view mocks

# WHY:
- `DeviceViewMockable` gives us possibility to create objects for specific test case, e.g.
```
struct Phone_4Inches: DeviceViewMockable {
    var name = "iPhone SE"
    var size = .init(width: 320.0, height: 568.0)
    var layoutMargins = .init(top: 8.0, left: 16.0, bottom: 8.0, right: 16.0)
    ...
}
```
- `MockingView` gives easy to use View mock container

# TO CONSIDER 🤔
- maybe `MockingView` should be called `StubingView`? Same for protocols.